### PR TITLE
Use cloud-init to set hostname

### DIFF
--- a/vagrant_plugin_guest_busybox.rb
+++ b/vagrant_plugin_guest_busybox.rb
@@ -10,26 +10,12 @@ module VagrantPlugins
     module Cap
       class ChangeHostName
         def self.change_host_name(machine, name)
-          new(machine, name).change!
-        end
-
-        attr_reader :machine, :new_hostname
-
-        def initialize(machine, new_hostname)
-          @machine = machine
-          @new_hostname = new_hostname
-        end
-
-        def change!
-          change_hostname_for_console
-        end
-
-        def change_hostname_for_console
           machine.communicate.tap do |comm|
-            if !comm.test("hostname -s | grep '^#{new_hostname}$'")
-              comm.sudo("sh -c 'echo \"#{new_hostname}\" > /etc/hostname'")
-              comm.sudo("hostname -F /etc/hostname")
-            end
+            comm.sudo("sh -c 'echo \"#cloud-config\" > /var/lib/rancher/conf/cloud-config.yml'")
+            comm.sudo("sh -c 'echo \"hostname: #{name}\" >> /var/lib/rancher/conf/cloud-config.yml'")
+            comm.sudo("rancherctl config set cloud_init.datasources '[file:/var/lib/rancher/conf/cloud-config.yml]'")
+            comm.sudo("system-docker restart cloud-init")
+            comm.sudo("cloud-init -execute")
           end
         end
       end


### PR DESCRIPTION
Try to set hostname, but it seems RancherOS's cloudinit doesn't support hostname yet.

https://github.com/rancherio/os/blob/master/cmd/cloudinit/cloudinit.go
